### PR TITLE
Dev/start at tile x

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -1,15 +1,17 @@
 [imaging_specs]
-local_storage_directory = "."#"D:\\"
-external_storage_directory = "."#"Y:\\"
+local_storage_directory = "D:\\"
+external_storage_directory =  "D:\\"   # "Y:\\"
 subject_id = "sim_test"
 tile_prefix = "tile"
 tile_overlap_x_percent = 15
 tile_overlap_y_percent = 10
 z_step_size_um = 1
-volume_x_um = 10615.616
-volume_y_um = 7958.7
-volume_z_um = 100
+volume_x_um = 10616  # 10615.616
+volume_y_um = 7959  # 7958.7
+volume_z_um = 64
 laser_wavelengths = [ 561,]
+#start_tile_index = 1
+#end_tile_index = 2
 
 [experiment_specs]
 experimenters_name = "Sim Robot"

--- a/bin/sim_config.toml
+++ b/bin/sim_config.toml
@@ -10,6 +10,8 @@ volume_x_um = 10615.616
 volume_y_um = 7958.7
 volume_z_um = 100
 laser_wavelengths = [ 561,]
+# start_tile_index = 0
+# end_tile_index = 0
 
 [experiment_specs]
 experimenters_name = "Sim Robot"

--- a/exaspim/exaspim_config.py
+++ b/exaspim/exaspim_config.py
@@ -112,6 +112,34 @@ class ExaspimConfig(SpimConfig):
     @z_step_size_um.setter
     def z_step_size_um(self, um: float):
         self.cfg['imaging_specs']['z_step_size_um'] = um
+
+    @property
+    def start_tile_index(self):
+        """If specified, the tile index from which to start collecting z stacks.
+
+        Note: z stack index must be in the range of [0, xtiles * ytiles - 1].
+
+        Note: z stack index increments first in the y dimension; then in the
+        x dimension. i.e: in a grid of 5 xtiles by 3 ytiles, tile "0" is (0, 0),
+        tile "2" is (0, 2), tile "3" is (1, 0), etc.
+        """
+        return self.imaging_specs.get('start_tile_index', None)
+
+    @start_tile_index.setter
+    def start_tile_index(self, index: int):
+        self.imaging_specs['start_tile_index'] = index
+
+    @property
+    def end_tile_index(self):
+        """If specified, the tile index from which to stop collecting z stacks,
+        i.e: the final stack to be collected. (See details on
+        :meth:`start_tile_index` for more details on tile indexing.)
+        """
+        return self.imaging_specs.get('end_tile_index', None)
+
+    @end_tile_index.setter
+    def end_tile_index(self, index):
+        self.imaging_specs['end_tile_index'] = index
         
     @property
     def stage_backlash_reset_dist_um(self):

--- a/exaspim/operations/waveform_generator.py
+++ b/exaspim/operations/waveform_generator.py
@@ -77,7 +77,7 @@ def generate_waveforms(cfg, plot: bool = False, channels: list[int] = None, live
         # Generate laser TTL signal
         voltages_t[ch][n2c_index[str(ch)],  # FIXME: remove n2c or move it into the config.
         int(etl_buffer_samples / 2.0) + camera_delay_samples:int(
-            etl_buffer_samples / 2.0) + camera_exposure_samples + dwell_time_samples + camera_delay_samples] = 10.0
+            etl_buffer_samples / 2.0) + camera_exposure_samples + dwell_time_samples + camera_delay_samples] = 2.0
 
         # Generate stage TTL signal
         if ch == channels_list[-1]:


### PR DESCRIPTION
Now you can put:

````toml
start_tile_index = 1
end_tile_index = 2
````

in your image acquisition parameters, and the acquisition will start at that tile or end after that tile. If left out or commented out, the full volume will be imaged.


Side note: it also looks like @adamkglaser reversed the y iteration order, and that made it into this commit.

## Testing
This works in simulation!